### PR TITLE
properly load files in exported version

### DIFF
--- a/RPChat/components/storage/Storage.gd
+++ b/RPChat/components/storage/Storage.gd
@@ -70,13 +70,18 @@ func _load_story_data():
 	var data_dir = DirAccess.open(self.data_directory + '/data')
 	if data_dir:
 		for file in list_files_in_directory(self.data_directory + '/data'):
-			# FIXME in actual deploy there should be no imports in data folders
 			# TODO add whitelist of known filetypes and only add those
 			if file.ends_with(".import"):
+				var imported_file = file.trim_suffix('.import')
+				var imported_path = self.data_directory + '/data/' + imported_file
+				if ResourceLoader.exists(imported_path) and not self.has_resource(imported_file):
+					self.loaded_resources.append(imported_file)
+					add_resource(imported_file, ResourceLoader.load(imported_path))
 				continue
 			
-			self.loaded_resources.append(file)
-			add_resource(file, load(self.data_directory + "/data/" + str(file)))
+			if not self.has_resource(file):
+				self.loaded_resources.append(file)
+				add_resource(file, load(self.data_directory + "/data/" + str(file)))
 
 
 func _remove_previous_resources():

--- a/RPChat/examples/demo/data/Synthwest.mp3.import
+++ b/RPChat/examples/demo/data/Synthwest.mp3.import
@@ -2,7 +2,7 @@
 
 importer="mp3"
 type="AudioStreamMP3"
-uid="uid://cgj2smttr2vg0"
+uid="uid://o6lxb723xnq6"
 path="res://.godot/imported/Synthwest.mp3-6dfea2c06ac31c24f1157b3e1a54c22f.mp3str"
 
 [deps]


### PR DESCRIPTION
The Godot Engine by default packs all known resource types into .import folder, to which originals are moved and only filename.import remains. This makes it impossible to load in a low-level way, however the ResourceLoader is capable of translating the original paths into .import ones.

Relevant GodotQuestions thread: https://godotengine.org/qa/59637/cannot-traverse-asset-directory-in-android